### PR TITLE
Add simple tap game for Telegram

### DIFF
--- a/crupto_project/settings.py
+++ b/crupto_project/settings.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
     'catalog',
     'blog',
     'finance',
+    'telegram_game',
 ]
 
 MIDDLEWARE = [

--- a/crupto_project/urls.py
+++ b/crupto_project/urls.py
@@ -3,5 +3,6 @@ from wagtail import urls as wagtail_urls
 
 urlpatterns = [
     path('admin/', include('wagtail.admin.urls')),
+    path('game/', include('telegram_game.urls')),
     path('', include(wagtail_urls)),
 ]

--- a/telegram_game/apps.py
+++ b/telegram_game/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class TelegramGameConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "telegram_game"

--- a/telegram_game/templates/telegram_game/index.html
+++ b/telegram_game/templates/telegram_game/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Tapolku Game</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; margin-top: 2em; }
+        #tap { font-size: 2em; padding: 1em 2em; }
+    </style>
+    <script>
+        let score = 0;
+        let timeLeft = 30;
+        let timer;
+
+        function tap() {
+            score++;
+            document.getElementById('score').textContent = score;
+        }
+
+        function countdown() {
+            timeLeft--;
+            document.getElementById('time').textContent = timeLeft;
+            if (timeLeft <= 0) {
+                clearInterval(timer);
+                document.getElementById('tap').disabled = true;
+                if (window.Telegram && Telegram.WebApp) {
+                    Telegram.WebApp.sendData(String(score));
+                }
+            }
+        }
+
+        window.onload = function() {
+            timer = setInterval(countdown, 1000);
+        }
+    </script>
+</head>
+<body>
+    <h1>Tapolku</h1>
+    <p>Score: <span id="score">0</span></p>
+    <p>Time left: <span id="time">30</span> seconds</p>
+    <button id="tap" onclick="tap()">Tap!</button>
+</body>
+</html>

--- a/telegram_game/urls.py
+++ b/telegram_game/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.index, name='telegram_game_index'),
+]

--- a/telegram_game/views.py
+++ b/telegram_game/views.py
@@ -1,0 +1,6 @@
+from django.shortcuts import render
+
+
+def index(request):
+    """Render the main Telegram game page."""
+    return render(request, "telegram_game/index.html")


### PR DESCRIPTION
## Summary
- add `telegram_game` app with a simple tap-based HTML5 mini game for Telegram
- register the app and URL route so `/game/` serves the game

## Testing
- `python manage.py test` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68b47a1f39648324b4f517339a1c9cb7