### PR TITLE
Add Flask iPhone store

### DIFF
--- a/iphone_shop/app.py
+++ b/iphone_shop/app.py
@@ -1,0 +1,27 @@
+from flask import Flask, render_template, abort
+
+app = Flask(__name__)
+
+IPHONES = [
+    {"slug": "iphone-15-pro-max", "name": "iPhone 15 Pro Max", "price": 1199, "description": "The ultimate iPhone experience with powerful A17 Pro chip and titanium design."},
+    {"slug": "iphone-15-pro", "name": "iPhone 15 Pro", "price": 999, "description": "Pro-class performance in a compact form."},
+    {"slug": "iphone-15-plus", "name": "iPhone 15 Plus", "price": 899, "description": "Large display with all‑day battery life."},
+    {"slug": "iphone-15", "name": "iPhone 15", "price": 799, "description": "The latest iPhone with powerful features and great value."},
+    {"slug": "iphone-14", "name": "iPhone 14", "price": 699, "description": "A popular choice with impressive capabilities."},
+    {"slug": "iphone-13", "name": "iPhone 13", "price": 599, "description": "Performance and camera in a classic design."},
+    {"slug": "iphone-se", "name": "iPhone SE", "price": 429, "description": "Compact and affordable with Touch ID."}
+]
+
+@app.route('/')
+def index():
+    return render_template('index.html', iphones=IPHONES)
+
+@app.route('/iphone/<slug>')
+def iphone_detail(slug):
+    model = next((i for i in IPHONES if i['slug'] == slug), None)
+    if model is None:
+        abort(404)
+    return render_template('detail.html', model=model)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/iphone_shop/static/styles.css
+++ b/iphone_shop/static/styles.css
@@ -1,0 +1,7 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+header, footer { background-color: #f5f5f5; padding: 1em; text-align: center; }
+main { padding: 1em; }
+.products { list-style: none; padding: 0; }
+.products li { margin: 0.5em 0; }
+a { text-decoration: none; color: #007bff; }
+a:hover { text-decoration: underline; }

--- a/iphone_shop/templates/base.html
+++ b/iphone_shop/templates/base.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}iPhone Store{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <header><h1><a href="{{ url_for('index') }}">iPhone Store</a></h1></header>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+  <footer><p>&copy; 2024 iPhone Store</p></footer>
+</body>
+</html>

--- a/iphone_shop/templates/detail.html
+++ b/iphone_shop/templates/detail.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block title %}{{ model.name }}{% endblock %}
+{% block content %}
+<h2>{{ model.name }}</h2>
+<p>Price: ${{ model.price }}</p>
+<p>{{ model.description }}</p>
+<p><a href="{{ url_for('index') }}">Back to all models</a></p>
+{% endblock %}

--- a/iphone_shop/templates/index.html
+++ b/iphone_shop/templates/index.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block title %}All iPhone Models{% endblock %}
+{% block content %}
+<ul class="products">
+  {% for phone in iphones %}
+  <li>
+    <a href="{{ url_for('iphone_detail', slug=phone.slug) }}">{{ phone.name }} - ${{ phone.price }}</a>
+  </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Django>=4.2
 wagtail>=5.0
 gunicorn
 psycopg2-binary
+
+Flask>=3.0


### PR DESCRIPTION
## Summary
- Build new Flask app with routes for listing iPhone models and detailed pages
- Add HTML templates and basic styling
- Include Flask dependency in requirements

## Testing
- `pip install Flask`
- `python -m py_compile iphone_shop/app.py`
- `python iphone_shop/app.py & sleep 2; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_68b47afbfbe88324a7bdc88e683eb2fa